### PR TITLE
DM-26987: Update filtering of matched catalog to operate before creating GroupView

### DIFF
--- a/ingredients/LSSTCam-imSim/DRP.yaml
+++ b/ingredients/LSSTCam-imSim/DRP.yaml
@@ -110,6 +110,9 @@ subsets:
       - matchCatalogsTract
       - matchCatalogsPatch
       - matchCatalogsPatchMultiBand
+      - matchCatalogsTractMag17to21p5
+      - matchCatalogsTractStarsSNR5to80
+      - matchCatalogsTractGxsSNR5to80
       - PA1
       - PF1_design
       - AM1

--- a/pipelines/HSC/DRP-RC2.yaml
+++ b/pipelines/HSC/DRP-RC2.yaml
@@ -127,6 +127,9 @@ subsets:
       - matchCatalogsTract
       - matchCatalogsPatch
       - matchCatalogsPatchMultiBand
+      - matchCatalogsTractMag17to21p5
+      - matchCatalogsTractStarsSNR5to80
+      - matchCatalogsTractGxsSNR5to80
       - PA1
       - PF1_design
       - AM1


### PR DESCRIPTION
The new tasks in `faro` for matched catalog creation also needed to be added to the default DRP.yaml pipelines here.