### PR TITLE
DM-33780: Add new faro tasks to all relevant subsets in drp_pipe

### DIFF
--- a/pipelines/HSC/DRP-RC2.yaml
+++ b/pipelines/HSC/DRP-RC2.yaml
@@ -226,6 +226,9 @@ subsets:
       - matchCatalogsTract
       - matchCatalogsPatch
       - matchCatalogsPatchMultiBand
+      - matchCatalogsTractMag17to21p5
+      - matchCatalogsTractStarsSNR5to80
+      - matchCatalogsTractGxsSNR5to80
       - PA1
       - PF1_design
       - AM1


### PR DESCRIPTION
I added the three new faro tasks that were included in the `faro_step3` subset on tickets/DM-26987 to the `step3` subset of DRP-RC2.yaml.

Jenkins job is running [here](https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/35950/pipeline).