### PR TITLE
DM-33959-fixup: Remove faro tasks from image proc subsets

### DIFF
--- a/pipelines/HSC/DRP-RC2.yaml
+++ b/pipelines/HSC/DRP-RC2.yaml
@@ -215,9 +215,6 @@ subsets:
       - fgcmBuildStarsTable
       - fgcmFitCycle
       - fgcmOutputProducts
-      - nsrcMeasVisit
-      - TE3
-      - TE4
     description: >
       Per-visit tasks that can be run together, but only after the 'step1'.
 
@@ -250,36 +247,6 @@ subsets:
       - healSparsePropertyMaps
       - selectGoodSeeingVisits
       - templateGen
-      - matchCatalogsTract
-      - matchCatalogsPatch
-      - matchCatalogsPatchMultiBand
-      - matchCatalogsTractMag17to21p5
-      - matchCatalogsTractStarsSNR5to80
-      - matchCatalogsTractGxsSNR5to80
-      - PA1
-      - PF1_design
-      - AM1
-      - AM2
-      - AM3
-      - AD1_design
-      - AD2_design
-      - AD3_design
-      - AF1_design
-      - AF2_design
-      - AF3_design
-      - AB1
-      - modelPhotRepGal1
-      - modelPhotRepGal2
-      - modelPhotRepGal3
-      - modelPhotRepGal4
-      - modelPhotRepStar1
-      - modelPhotRepStar2
-      - modelPhotRepStar3
-      - modelPhotRepStar4
-      - psfPhotRepStar1
-      - psfPhotRepStar2
-      - psfPhotRepStar3
-      - psfPhotRepStar4
     description: >
       Tasks that can be run together, but only after the 'step1' and 'step2'
       subsets.
@@ -324,11 +291,6 @@ subsets:
       - writeForcedSourceOnDiaObjectTable
       - transformForcedSourceOnDiaObjectTable
       - consolidateForcedSourceOnDiaObjectTable
-      - TE1
-      - TE2
-      - wPerp
-      - skyObjectMean
-      - skyObjectStd
     description: >
       Tasks that can be run together, but only after the 'step1', 'step2',
       'step3', and 'step4' subsets


### PR DESCRIPTION
This commit was supposed to follow shortly on DM-34853.
Without it steps3 and step5 will make empty quantum graphs
unless step6 is run first, so it's being committed as a hotfix.