### PR TITLE
DM-40171: Reraise partial-template image subtraction failures as NoWorkFound 

### DIFF
--- a/pipelines/HSC/DRP-ci_hsc.yaml
+++ b/pipelines/HSC/DRP-ci_hsc.yaml
@@ -45,12 +45,6 @@ tasks:
     config:
       # Only run the deblender on a small subset of blended parents
       deblend.useCiLimits: true
-  subtractImages:
-    class: lsst.ip.diffim.subtractImages.AlardLuptonSubtractTask
-    # Increase required area of usable template so we raise NoWorkFound
-    # instead of bringing down execution.
-    config:
-      requiredTemplateFraction: 0.2
   writeRecalibratedSourceTable:
     class: lsst.pipe.tasks.postprocess.WriteRecalibratedSourceTableTask
     config:

--- a/pipelines/LSSTCam-imSim/DRP-ci_imsim.yaml
+++ b/pipelines/LSSTCam-imSim/DRP-ci_imsim.yaml
@@ -23,12 +23,6 @@ tasks:
     config:
       # Only run the deblender on a small subset of blended parents
       deblend.useCiLimits: true
-  subtractImages:
-    class: lsst.ip.diffim.subtractImages.AlardLuptonSubtractTask
-    # Increase required area of usable template so we raise NoWorkFound
-    # instead of bringing down execution.
-    config:
-      requiredTemplateFraction: 0.2
 subsets:
   analysis_tools:
     subset:


### PR DESCRIPTION
subtractImages now raises NoWorkFound if the template fraction is less than 0.2 and PSF-matching fails