### PR TITLE
DM-41503: Add selectDeepCoaddVisits to DRP pipelines to select by seeing.

### DIFF
--- a/pipelines/HSC/DRP-Prod.yaml
+++ b/pipelines/HSC/DRP-Prod.yaml
@@ -100,6 +100,7 @@ subsets:
   step3:
     subset:
       - makeWarp
+      - selectDeepCoaddVisits
       - assembleCoadd
       - detection
       - mergeDetections

--- a/pipelines/HSC/DRP-RC2.yaml
+++ b/pipelines/HSC/DRP-RC2.yaml
@@ -142,6 +142,7 @@ subsets:
   step3:
     subset:
       - makeWarp
+      - selectDeepCoaddVisits
       - assembleCoadd
       - detection
       - mergeDetections

--- a/pipelines/HSC/DRP-RC2_subset.yaml
+++ b/pipelines/HSC/DRP-RC2_subset.yaml
@@ -327,6 +327,7 @@ subsets:
   nightlyStep3:
     subset:
       - makeWarp
+      - selectDeepCoaddVisits
       - assembleCoadd
       - detection
       - mergeDetections

--- a/pipelines/LATISS/DRP.yaml
+++ b/pipelines/LATISS/DRP.yaml
@@ -39,6 +39,13 @@ tasks:
       photo_calib_provider: "global"
       background_provider: "input_summary"
 
+  selectDeepCoaddVisits:
+    class: lsst.pipe.tasks.selectImages.BestSeeingSelectVisitsTask
+    config:
+      # This is the maximum seeing that can be used with the default 71 pixel
+      # psf kernel size.
+      maxPsfFwhm: 1.9
+
   # Importing and defining analyzeObjectTableCore here to omit plots that
   # require z and/or y band data.
   analyzeObjectTableCore:

--- a/pipelines/LATISS/DRP.yaml
+++ b/pipelines/LATISS/DRP.yaml
@@ -118,6 +118,7 @@ subsets:
   step3a:
     subset:
       - makeWarp
+      - selectDeepCoaddVisits
       - assembleCoadd
       - detection
       - mergeDetections

--- a/pipelines/_ingredients/DECam/DRP.yaml
+++ b/pipelines/_ingredients/DECam/DRP.yaml
@@ -197,6 +197,7 @@ subsets:
   step3:
     subset:
       - selectGoodSeeingVisits
+      - selectDeepCoaddVisits
       - makeWarp
       - templateGen
       - deblend

--- a/pipelines/_ingredients/DRP-minimal-calibration.yaml
+++ b/pipelines/_ingredients/DRP-minimal-calibration.yaml
@@ -22,10 +22,21 @@ tasks:
     class: lsst.pipe.tasks.makeWarp.MakeWarpTask
     config:
       makePsfMatched: true
+  selectDeepCoaddVisits:
+    class: lsst.pipe.tasks.selectImages.BestSeeingSelectVisitsTask
+    config:
+      connections.goodVisits: deepCoaddVisits
+      # Maximum sensible default psf fwhm in arcseconds to use for a coadd
+      maxPsfFwhm: 2.0
+      # By default for deep coadds, use all input visits better than maxPsfFwhm
+      nVisitsMax: -1
   assembleCoadd:
     class: lsst.drp.tasks.assemble_coadd.CompareWarpAssembleCoaddTask
     config:
       doInputMap: true
+      doSelectVisits: true
+      assembleStaticSkyModel.doSelectVisits: true
+      connections.selectedVisits: deepCoaddVisits
   healSparsePropertyMaps: lsst.pipe.tasks.healSparseMapping.HealSparsePropertyMapTask
   consolidateHealSparsePropertyMaps: lsst.pipe.tasks.healSparseMapping.ConsolidateHealSparsePropertyMapTask
   detection: lsst.pipe.tasks.multiBand.DetectCoaddSourcesTask

--- a/pipelines/_ingredients/LSSTCam-imSim/DRP.yaml
+++ b/pipelines/_ingredients/LSSTCam-imSim/DRP.yaml
@@ -142,6 +142,7 @@ subsets:
   step3:
     subset:
       - makeWarp
+      - selectDeepCoaddVisits
       - assembleCoadd
       - detection
       - mergeDetections

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -78,6 +78,7 @@ COMMON_OUTPUTS = {
     "calexp",
     "calexpBackground",
     "ccdVisitTable",
+    "deepCoaddVisits",
     "deepCoadd",
     "deepCoadd_calexp",
     "deepCoadd_calexp_background",


### PR DESCRIPTION
This ticket adds a sensible default for seeing selection, plus a specific cut for LATISS processing.