### PR TITLE
Update LATISS DRP.yaml to move 3 *SourceTable tasks

### DIFF
--- a/pipelines/LATISS/DRP.yaml
+++ b/pipelines/LATISS/DRP.yaml
@@ -135,6 +135,9 @@ subsets:
       - fgcmBuildFromIsolatedStars
       - fgcmFitCycle
       - fgcmOutputProducts
+      - writeRecalibratedSourceTable
+      - transformSourceTable
+      - consolidateSourceTable
       - updateVisitSummary
       - makeCcdVisitTable
       - makeVisitTable
@@ -221,8 +224,6 @@ subsets:
       - detectAndMeasureDiaSources
       - transformDiaSourceCat
       - writeForcedSourceTable
-      - writeRecalibratedSourceTable
-      - transformSourceTable
     description: |
       Tasks that be run together, but only after the 'step1', 'step2', and
       'step3' subsets.
@@ -256,7 +257,6 @@ subsets:
   step6:
     subset:
       - consolidateDiaSourceTable
-      - consolidateSourceTable
     description: |
       Tasks that can be run together, but only after the 'step1', 'step2',
       'step3', 'step4', and 'step5' subsets.


### PR DESCRIPTION
Update LATISS DRP.yaml to move the 3 tasks writeRecalibratedSourceTable, transformSourceTable (both in step4), and consolidateSourceTable (in step6) to step2bcde.   This is in response to comments by Lauren MacArthur to run these tasks as early as possible so outputs are available for QA scripts, and by Clare Saunders that the sourceTable_visits outputs of consolidateSourceTable are needed by the analysis tasks in step3c.