### PR TITLE
DM-42307: Separate clustering.yaml for DC2 and RC2 cases

### DIFF
--- a/bps/clustering/DRP-recalibrated.yaml
+++ b/bps/clustering/DRP-recalibrated.yaml
@@ -12,7 +12,7 @@
 clusterAlgorithm: lsst.ctrl.bps.quantum_clustering_funcs.dimension_clustering
 cluster:
   visit_detector:
-    pipetasks: isr,inject_exposure,characterizeImage,calibrate,inject_visit,writePreSourceTable,transformPreSourceTable,writeSourceTable,transformSourceTable
+    pipetasks: isr,inject_exposure,characterizeImage,calibrate,inject_visit,writePreSourceTable,transformPreSourceTable
     dimensions: visit,detector
     equalDimensions: visit:exposure
 

--- a/bps/clustering/HSC/DRP-RC2-clustering.yaml
+++ b/bps/clustering/HSC/DRP-RC2-clustering.yaml
@@ -1,0 +1,12 @@
+#
+# For HSC campaigns, one uses the default clustering file
+# without changes.
+#
+# Use it by adding:
+#
+#   includeConfigs:
+#     - ${DRP_PIPE_DIR}/bps/clustering/HSC/DRP-RC2-clustering.yaml
+#
+# (with no outer indentation) to your BPS config file.
+imports:
+  - $DRP_PIPE_DIR/bps/clustering/DRP-recalibrated.yaml

--- a/bps/clustering/LSSTCam-imSim/DRP-DC2-clustering.yaml
+++ b/bps/clustering/LSSTCam-imSim/DRP-DC2-clustering.yaml
@@ -1,0 +1,26 @@
+#
+# For DC2 campaigns, the visit_detector (step1) clustering is modified since
+# astrometric and photometric calibration are skipped in DC2
+# this file swaps out two pipetasks: writePreSourceTable and
+# transformPreSourceTable and replaces them with
+# writeSourceTable and transformSourceTable
+# for step1 clustering.
+#
+# Use it by adding:
+#
+#   includeConfigs:
+#     - ${DRP_PIPE_DIR}/bps/clustering/LSSTCam-imSim/DRP-DC2-clustering.yaml
+#
+# (with no outer indentation) to your BPS config file.
+#
+imports:
+  - location: "$DRP_PIPE_DIR/bps/clustering/DRP-recalibrated.yaml"
+    exclude:
+      - visit_detector
+      - sourceTable
+
+cluster:
+  visit_detector:
+    pipetasks: isr,inject_exposure,characterizeImage,calibrate,inject_visit,writeSourceTable,transformSourceTable
+    dimensions: visit,detector
+    equalDimensions: visit:exposure


### PR DESCRIPTION
- visit_detector (step1) clustering requires distinct pipetask lists for
- DC2 (LSSTCam-imsim) and RC2 (HSC) cases