### PR TITLE
DM-45705: increase requestMemory for assembleCoadd and detection to 16GB (was 4-8)

### DIFF
--- a/bps/resources/HSC/DRP-RC2.yaml
+++ b/bps/resources/HSC/DRP-RC2.yaml
@@ -25,7 +25,7 @@ pipetask:
   fgcmOutputProducts:
     requestMemory: 8192
   assembleCoadd:
-    requestMemory: 8192
+    requestMemory: 16384
   jointcal:
     requestMemory: 21000
   deblend:
@@ -63,7 +63,7 @@ pipetask:
   makeCcdVisitTable:
     requestMemory: 10000
   detection:
-    requestMemory: 8000
+    requestMemory: 16384
 
   # step8 tasks - sasquatch
   analyzeObjectTableCore:

--- a/bps/resources/LSSTCam-imSim/DRP-DP0.2.yaml
+++ b/bps/resources/LSSTCam-imSim/DRP-DP0.2.yaml
@@ -14,6 +14,8 @@ pipetask:
     requestMemory: 8192
   assembleCoadd:
     requestMemory: 16384
+  detection:
+    requestMemory: 16384
   deblend:
     requestMemory: 16384
   measure:

--- a/bps/resources/LSSTCam-imSim/DRP-test-med-1.yaml
+++ b/bps/resources/LSSTCam-imSim/DRP-test-med-1.yaml
@@ -18,7 +18,9 @@ pipetask:
   measure:
     requestMemory: 10000
   detection:
-    requestMemory: 8000
+    requestMemory: 16384
+  assembleCoadd:
+    requestMemory: 16384
   transformObjectTable:
     requestMemory: 16384
   writeObjectTable:


### PR DESCRIPTION
With recent changes to assembleCoadd (DM-45366 and related) memory usage has increased above 8GB (was 12GB for recent DC2).  Therefore, we are increasing the amount of requestedMemory for assembleCoadd (and detection, which is clustered with it) to 16GB.