### PR TITLE
DM-46684: Add Metrics to calibrateImage task metadata

### DIFF
--- a/pipelines/_ingredients/HSC/DRP.yaml
+++ b/pipelines/_ingredients/HSC/DRP.yaml
@@ -9,7 +9,6 @@ imports:
   - $ANALYSIS_TOOLS_DIR/pipelines/exposureQualityCore.yaml
   - $ANALYSIS_TOOLS_DIR/pipelines/matchedVisitQualityCore.yaml
   - $ANALYSIS_TOOLS_DIR/pipelines/visitQualityCore.yaml
-  - $ANALYSIS_TOOLS_DIR/pipelines/calexpMetrics.yaml
   - $ANALYSIS_TOOLS_DIR/pipelines/wholeSkyCore.yaml
 tasks:
   isr:


### PR DESCRIPTION
calexpMetrics.yaml has been removed from analysis_tools as part of this same ticket. Its functionality has been moved to visitQualityCore.yaml.

Note: this will fail tests on the standard build until the standard build runs the calibrateImage to generate calibrateImage_metadata.