### PR TITLE
DM-47331: increase requestMemory for DC2 consolidateForcedSourceTable 

### DIFF
--- a/bps/resources/LSSTCam-imSim/DRP-test-med-1.yaml
+++ b/bps/resources/LSSTCam-imSim/DRP-test-med-1.yaml
@@ -29,6 +29,10 @@ pipetask:
     requestMemory: 8192
   consolidateObjectTable:
     requestMemory: 16384
+  consolidateForcedSourceTable:
+    requestMemory: 100000
+  consolidateForcedSourceOnDiaObjectTable:
+    requestMemory: 18000
   getTemplate:
     requestMemory: 8000
   subtractImages:


### PR DESCRIPTION
With DC2 doing more, the pipetasks consolidateForcedSourceTable now needs more memory to run,
up to about 66GB for a regular DC2 (and 100GB+ for RC2) We also bump the memory on consolidateForcedSourceOnDiaObjectTable from the default to 18GB, as that is needed for RC2.