### PR TITLE
DM-47171: Restrict visits to ComCam coadds to 2.0 arcsec FWHM

### DIFF
--- a/pipelines/_ingredients/LSSTComCam/DRP.yaml
+++ b/pipelines/_ingredients/LSSTComCam/DRP.yaml
@@ -35,15 +35,6 @@ tasks:
       psf_determiner.name: "psfex"
       python: |
         import lsst.meas.extensions.psfex.psfexPsfDeterminer
-  selectDeepCoaddVisits:
-    class: lsst.pipe.tasks.selectImages.BestSeeingSelectVisitsTask
-    config:
-      connections.goodVisits: deepCoaddVisits
-      # Maximum default psf fwhm in arcseconds to use for a coadd in
-      # early commissioning.
-      maxPsfFwhm: 2.7
-      # By default for deep coadds, use all input visits better than maxPsfFwhm
-      nVisitsMax: -1
   selectGoodSeeingVisits:
     class: lsst.pipe.tasks.selectImages.BestSeeingQuantileSelectVisitsTask
     config:


### PR DESCRIPTION
The default is 2.0. Image quality has improved to the point that the permissive override is no longer needed