### PR TITLE
DM-48145: Switch back to initial visitSummary in preSource analysis.

### DIFF
--- a/pipelines/_ingredients/LSSTCam/DRP.yaml
+++ b/pipelines/_ingredients/LSSTCam/DRP.yaml
@@ -79,6 +79,7 @@ tasks:
     config:
       connections.catalog: "preSourceTable_visit"
       connections.targetCatalog: "preSourceTable_visit"
+      connections.visitSummaryTable: "visitSummary"
   astrometricRefCatPreSourceVisit:
     class: lsst.analysis.tools.tasks.refCatSourceAnalysis.RefCatSourceAnalysisTask
     config:
@@ -125,6 +126,7 @@ tasks:
       connections.catalog: preSourceTable_visit
       connections.targetCatalog: preSourceTable_visit
       connections.matchedCatalog: preSourceTable_visit_gaia_dr3_20230707_photoMatch
+      connections.visitSummaryTable: "visitSummary"
   photometricRefCatPreSourceVisit:
     class: lsst.analysis.tools.tasks.refCatSourcePhotometricAnalysis.RefCatSourcePhotometricAnalysisTask
     config:

--- a/pipelines/_ingredients/LSSTComCam/DRP.yaml
+++ b/pipelines/_ingredients/LSSTComCam/DRP.yaml
@@ -111,6 +111,7 @@ tasks:
     config:
       connections.catalog: "preSourceTable_visit"
       connections.targetCatalog: "preSourceTable_visit"
+      connections.visitSummaryTable: "visitSummary"
   astrometricRefCatPreSourceVisit:
     class: lsst.analysis.tools.tasks.refCatSourceAnalysis.RefCatSourceAnalysisTask
     config:
@@ -157,6 +158,7 @@ tasks:
       connections.catalog: preSourceTable_visit
       connections.targetCatalog: preSourceTable_visit
       connections.matchedCatalog: preSourceTable_visit_the_monster_20240904_photoMatch
+      connections.visitSummaryTable: "visitSummary"
   photometricRefCatPreSourceVisit:
     class: lsst.analysis.tools.tasks.refCatSourcePhotometricAnalysis.RefCatSourcePhotometricAnalysisTask
     config:

--- a/pipelines/_ingredients/LSSTComCamSim/DRP.yaml
+++ b/pipelines/_ingredients/LSSTComCamSim/DRP.yaml
@@ -92,6 +92,7 @@ tasks:
     config:
       connections.catalog: "preSourceTable_visit"
       connections.targetCatalog: "preSourceTable_visit"
+      connections.visitSummaryTable: "visitSummary"
   astrometricRefCatPreSourceVisit:
     class: lsst.analysis.tools.tasks.refCatSourceAnalysis.RefCatSourceAnalysisTask
     config:


### PR DESCRIPTION
This counteracts a defaults change upstream in analysis_tools.