### PR TITLE
DM-48269: add rbClassify to clustering directives for HSC, LSSTCam-imSim, remove finalSourceTable cluster

### DIFF
--- a/bps/clustering/DRP-recalibrated.yaml
+++ b/bps/clustering/DRP-recalibrated.yaml
@@ -19,17 +19,12 @@ cluster:
     pipetasks: assembleCoadd,inject_coadd,templateGen,detection
     dimensions: tract,patch,band
 
-  finalizeSourceTable:
-    pipetasks: finalizeCharacterization,updateVisitSummary,writeRecalibratedSourceTable,transformSourceTable,consolidateSourceTable
-    dimensions: visit
-    equalDimensions: visit:exposure
-
   objectTable:
     pipetasks: writeObjectTable,transformObjectTable
     dimensions: tract,patch
 
   diffim:
-    pipetasks: getTemplate,subtractImages,detectAndMeasureDiaSources,transformDiaSourceCat
+    pipetasks: getTemplate,subtractImages,detectAndMeasureDiaSources,rbClassify,transformDiaSourceCat
     dimensions: visit,detector
 
   association:
@@ -43,3 +38,10 @@ cluster:
   forced_phot_dia:
     pipetasks: forcedPhotDiffOnDiaObjects, forcedPhotCcdOnDiaObjects, writeForcedSourceOnDiaObjectTable
     dimensions: visit,detector,tract
+
+
+# removing this cluster pending fix of DM-48222
+# finalizeSourceTable:
+#   pipetasks: finalizeCharacterization,updateVisitSummary,writeRecalibratedSourceTable,transformSourceTable,consolidateSourceTable
+#   dimensions: visit
+#   equalDimensions: visit:exposure

--- a/bps/clustering/LSSTCam-imSim/DRP-DC2-clustering.yaml
+++ b/bps/clustering/LSSTCam-imSim/DRP-DC2-clustering.yaml
@@ -23,7 +23,7 @@ cluster:
     dimensions: tract,patch
 
   diffim:
-    pipetasks: getTemplate,subtractImages,detectAndMeasureDiaSources,transformDiaSourceCat
+    pipetasks: getTemplate,subtractImages,detectAndMeasureDiaSources,rbClassify,transformDiaSourceCat
     dimensions: visit,detector
 
   association:


### PR DESCRIPTION
Add in rbClassify to allow clustering for HSC, LSSTCam-imSIm processing also remove clustering of finalSourceTable pipetasks since this exceeds 4K character limit for panDA processing.