### PR TITLE
DM-49155: Add illumination corrections to mock LSSTComCam inputs.

### DIFF
--- a/pipelines/_ingredients/DRP-full.yaml
+++ b/pipelines/_ingredients/DRP-full.yaml
@@ -112,3 +112,5 @@ subsets:
 
 contracts:
   - skyCorr.doApplyFlatBackgroundRatio == calibrateImage.do_illumination_correction
+  - fgcmBuildFromIsolatedStars.doApplyWcsJacobian == False if calibrateImage.do_illumination_correction else True
+  - fgcmBuildFromIsolatedStars.doApplyWcsJacobian == fgcmOutputProducts.doComposeWcsJacobian

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -107,6 +107,7 @@ LSSTCOMCAM_INPUTS = {
     "defects",
     "cti",
     "the_monster_20250219",
+    "illuminationCorrection",
 }
 
 # LSSTComCamSim common inputs, in addition to COMMON_INPUTS


### PR DESCRIPTION
This had to be a completely fresh commit in order for github to let me make a PR.