### PR TITLE
DM-49368-v29: Remove skyCorr from LSSTComCam pipelines

### DIFF
--- a/pipelines/_ingredients/LSSTComCam/DRP.yaml
+++ b/pipelines/_ingredients/LSSTComCam/DRP.yaml
@@ -1,7 +1,9 @@
 description: DRP Pipeline for ComCam
 instrument: lsst.obs.lsst.LsstComCam
 imports:
-  - $DRP_PIPE_DIR/pipelines/_ingredients/DRP-full.yaml
+  - location: $DRP_PIPE_DIR/pipelines/_ingredients/DRP-full.yaml
+    exclude:
+      - skyCorr
   - $ANALYSIS_TOOLS_DIR/pipelines/coaddColumnValidate.yaml
   - $ANALYSIS_TOOLS_DIR/pipelines/coaddQualityCore.yaml
   - $ANALYSIS_TOOLS_DIR/pipelines/coaddQualityExtended.yaml


### PR DESCRIPTION
It was decided that SkyCorrectionTask should not be run on LSSTComCam datasets (see DM-47176 for more details).
As such, skyCorr does not appear in any currently run LSSTComCam steps. Excluding skyCorr from LSSTComCam pipeline YAMLs cleans up any potential contract failures that would exist as a result of this unused and non-configured task.