### PR TITLE
DM-50735: run FitVisitBackgroundTask in FL pipelines

### DIFF
--- a/pipelines/LSSTCam/DRP-FL.yaml
+++ b/pipelines/LSSTCam/DRP-FL.yaml
@@ -65,7 +65,6 @@ tasks:
     config:
       doApplySkyCorr: true
       connections.visit_summary: preliminary_visit_summary
-      connections.background_revert_list: preliminary_visit_image_background
   selectDeepCoaddVisits:
     class: lsst.pipe.tasks.selectImages.BestSeeingSelectVisitsTask
     config:

--- a/pipelines/LSSTCam/DRP-FL.yaml
+++ b/pipelines/LSSTCam/DRP-FL.yaml
@@ -122,15 +122,18 @@ tasks:
       connections.calBkgs: preliminary_visit_image_background
       connections.calExpMosaic: preliminary_visit_image_skyCorr_visit_mosaic
       connections.calBkgMosaic: preliminary_visit_image_background_skyCorr_visit_mosaic
-
+  fitVisitBackground:
+    class: lsst.drp.tasks.fit_visit_background.FitVisitBackgroundTask
 subsets:
   step2c-recalibrate-visits:
     subset:
       - skyCorr
+      - fitVisitBackground
     description: >
       A step that runs visit-level per-visit background estimation
   stage2-recalibrate:
     subset:
       - skyCorr
+      - fitVisitBackground
     description: >
       A one step stage

--- a/pipelines/LSSTCam/nightly-validation-FL.yaml
+++ b/pipelines/LSSTCam/nightly-validation-FL.yaml
@@ -23,3 +23,10 @@ tasks:
     class: lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask
     config:
       connections.background_apply_list: visit_background_diff
+  skyCorr:
+    class: lsst.pipe.tasks.skyCorrection.SkyCorrectionTask
+    config:
+      doBgModel2: true
+      bgModel2.xSize: 20.48  # 2048 * 0.01 mm
+      bgModel2.ySize: 20.48  # 2048 * 0.01 mm
+      bgModel2.pixelSize: 0.01  # mm per pixel

--- a/pipelines/LSSTCam/nightly-validation-FL.yaml
+++ b/pipelines/LSSTCam/nightly-validation-FL.yaml
@@ -19,3 +19,7 @@ tasks:
     class: lsst.drp.tasks.assemble_coadd.CompareWarpAssembleCoaddTask
     config:
       doFilterMorphological: true
+  makeDirectWarp:
+    class: lsst.drp.tasks.make_direct_warp.MakeDirectWarpTask
+    config:
+      connections.background_apply_list: visit_background_diff


### PR DESCRIPTION
First two commits can go in whenever.  Last commit is what actually switches what `MakeDirectWarpTask` uses.