### PR TITLE
DM-50907: Add new expected overall input for FL CI.

### DIFF
--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -716,7 +716,7 @@ class PipelineTestCase(unittest.TestCase):
                 "#stage3-coadd",
             ],
             initial_dataset_types=REFCATS,
-            expected_inputs=COMMON_INPUTS | LSSTCAM_INPUTS,
+            expected_inputs=COMMON_INPUTS | LSSTCAM_INPUTS | {"sky_frame_background"},
             # Check for some basic outputs
             expected_outputs={"preliminary_visit_image",
                               "preliminary_visit_summary",


### PR DESCRIPTION
We probably don't care about this pipeline anymore, but on this ticket I'd rather fix the test than remove the pipeline.