### PR TITLE
DM-50938-fix: Remove unneeded assembleDeepCoadd override

### DIFF
--- a/pipelines/LSSTCam/DRP-FL.yaml
+++ b/pipelines/LSSTCam/DRP-FL.yaml
@@ -105,7 +105,6 @@ tasks:
   skyCorr:
     class: lsst.pipe.tasks.skyCorrection.SkyCorrectionTask
     config:
-      # If you change any of these, consider changing it back in DRP-FL
       maskObjects.detection.isotropicGrow: false
       maskObjects.detection.thresholdType: stdev
       bgModel1.xSize: 81.92  # 8192 pixels

--- a/pipelines/LSSTCam/DRP.yaml
+++ b/pipelines/LSSTCam/DRP.yaml
@@ -80,14 +80,6 @@ tasks:
       detection.reEstimateBackground: true
       detection.background.binSize: 128
       detection.background.useApprox: false
-  assembleDeepCoadd:
-    class: lsst.drp.tasks.assemble_coadd.CompareWarpAssembleCoaddTask
-    config:
-      # Preliminary aggressive adjustment to accomodate early commissioning
-      maxFractionEpochsHigh: 0.1
-      # Shrink regions protected from clipping conservatively
-      detectTemplate.nSigmaToGrow: 1.2
-      detectTemplate.thresholdValue: 100
   reprocessVisitImage:
     class: lsst.drp.tasks.reprocess_visit_image.ReprocessVisitImageTask
     config:


### PR DESCRIPTION
Necessary configs we're placed in obs_lsst. These
were left in by accident.