### PR TITLE
Remove assembleCellCoadd from RC2_subset

### DIFF
--- a/pipelines/HSC/DRP-RC2_subset.yaml
+++ b/pipelines/HSC/DRP-RC2_subset.yaml
@@ -143,7 +143,6 @@ subsets:
       - makePsfMatchedWarp
       - selectDeepCoaddVisits
       - assembleCoadd
-      - assembleCellCoadd
       - detection
       - mergeDetections
       - deconvolve


### PR DESCRIPTION
The nightly verify_drp runs this pipeline with a non cell-based `hsc_rings_v1` pipeline. Until that is fixed, we will have to exclude this from being run.