### PR TITLE
DM-51646: increase memory for splitPrimaryObject (20GB) splitPrimaryObjectForcedSource (4GB)

### DIFF
--- a/bps/resources/HSC/DRP-RC2.yaml
+++ b/bps/resources/HSC/DRP-RC2.yaml
@@ -74,3 +74,9 @@ pipetask:
     requestMemory: 32000
   fitDeblendedObjectsSersic:
     requestMemory: 8000
+  splitPrimaryObject:
+    requestMemory: 20254
+  splitPrimaryObjectForcedSource:
+    requestMemory: 4000
+  splitPrimarySource:
+    requestMemory: 4000

--- a/bps/resources/LSSTComCam/DRP.yaml
+++ b/bps/resources/LSSTComCam/DRP.yaml
@@ -77,3 +77,9 @@ pipetask:
     requestMemory: 8000
   mergeMultiprofit:
     requestMemory: 8000
+  splitPrimaryObject:
+    requestMemory: 20254
+  splitPrimaryObjectForcedSource:
+    requestMemory: 4000
+  splitPrimarySource:
+    requestMemory: 4000


### PR DESCRIPTION
and splitPrimarySource (4GB) for instruments HSC and LSSTComCam also increased memory for splitPrimaryObjectForcedSource (same change already made for LSSTCam instrument earlier).