### PR TITLE
DM-50988: Flag DIASources consistent with glints from rotating space junk

### DIFF
--- a/tests/migration_data/LSSTComCam/DRP-v2.json
+++ b/tests/migration_data/LSSTComCam/DRP-v2.json
@@ -640,6 +640,7 @@
     "template_matched": "goodSeeingDiff_matchedExp",
     "dia_source_unfiltered": "goodSeeingDiff_diaSrc",
     "difference_image": "goodSeeingDiff_differenceExp",
+    "trailed_glints": "trailed_glints",
     "dia_source_unstandardized": "goodSeeingDiff_candidateDiaSrc",
     "long_trailed_dia_source": "goodSeeingDiff_longTrailedSrc",
     "rejected_dia_source": "goodSeeingDiff_rejectedDiaSrc",


### PR DESCRIPTION
This PR adds the new trailed_glints output data product, produced by detectAndMeasureDiaSource, to the DRP pipeline correspondence file.