### PR TITLE
DM-52272: Update drp_pipe quickLook {bias, dark, flat} to allow analysis_tools tasks to run

### DIFF
--- a/pipelines/LATISS/quickLookBias.yaml
+++ b/pipelines/LATISS/quickLookBias.yaml
@@ -7,11 +7,16 @@ imports:
   - location: $CP_VERIFY_DIR/pipelines/LATISS/verifyBias.yaml
     include:
       - verifyBiasIsr
+      - verifyBiasDet
+      - verifyBiasExp
+      - verifyBias
 
 tasks:
   verifyBiasIsr:
     class: lsst.ip.isr.IsrTaskLSST
     config:
       connections.outputExposure: post_isr_image
-      # Make sure interpolation is on.
-      doInterpolate: true
+  verifyBiasDet:
+    class: lsst.cp.verify.CpVerifyBiasTask
+    config:
+      connections.inputExp: post_isr_image

--- a/pipelines/LATISS/quickLookDark.yaml
+++ b/pipelines/LATISS/quickLookDark.yaml
@@ -7,6 +7,9 @@ imports:
   - location: $CP_VERIFY_DIR/pipelines/LATISS/verifyDark.yaml
     include:
       - verifyDarkIsr
+      - verifyDarkDet
+      - verifyDarkExp
+      - verifyDark
 
 tasks:
   verifyDarkIsr:
@@ -15,3 +18,7 @@ tasks:
       connections.outputExposure: post_isr_image
       # Make sure interpolation is on.
       doInterpolate: true
+  verifyDarkDet:
+    class: lsst.cp.verify.CpVerifyDarkTask
+    config:
+      connections.inputExp: post_isr_image

--- a/pipelines/LATISS/quickLookFlat.yaml
+++ b/pipelines/LATISS/quickLookFlat.yaml
@@ -7,13 +7,16 @@ imports:
   - location: $CP_VERIFY_DIR/pipelines/LATISS/verifyFlat.yaml
     include:
       - verifyFlatIsr
+      - verifyFlatDet
+      - verifyFlatExp
+      - verifyFlat
 
 tasks:
   verifyFlatIsr:
     class: lsst.ip.isr.IsrTaskLSST
     config:
       connections.outputExposure: post_isr_image
-      # Make sure brighter-fatter is off.
-      doBrighterFatter: false
-      # Make sure interpolation is on.
-      doInterpolate: true
+  verifyFlatDet:
+    class: lsst.cp.verify.CpVerifyFlatTask
+    config:
+      connections.inputExp: post_isr_image

--- a/pipelines/LSSTCam/quickLookBias.yaml
+++ b/pipelines/LSSTCam/quickLookBias.yaml
@@ -7,11 +7,16 @@ imports:
   - location: $CP_VERIFY_DIR/pipelines/LSSTCam/verifyBias.yaml
     include:
       - verifyBiasIsr
+      - verifyBiasDet
+      - verifyBiasExp
+      - verifyBias
 
 tasks:
   verifyBiasIsr:
     class: lsst.ip.isr.IsrTaskLSST
     config:
       connections.outputExposure: post_isr_image
-      # Make sure interpolation is on.
-      doInterpolate: true
+  verifyBiasDet:
+    class: lsst.cp.verify.CpVerifyBiasTask
+    config:
+      connections.inputExp: post_isr_image

--- a/pipelines/LSSTCam/quickLookDark.yaml
+++ b/pipelines/LSSTCam/quickLookDark.yaml
@@ -7,6 +7,9 @@ imports:
   - location: $CP_VERIFY_DIR/pipelines/LSSTCam/verifyDark.yaml
     include:
       - verifyDarkIsr
+      - verifyDarkDet
+      - verifyDarkExp
+      - verifyDark
 
 tasks:
   verifyDarkIsr:
@@ -15,3 +18,7 @@ tasks:
       connections.outputExposure: post_isr_image
       # Make sure interpolation is on.
       doInterpolate: true
+  verifyDarkDet:
+    class: lsst.cp.verify.CpVerifyDarkTask
+    config:
+      connections.inputExp: post_isr_image

--- a/pipelines/LSSTCam/quickLookFlat.yaml
+++ b/pipelines/LSSTCam/quickLookFlat.yaml
@@ -7,14 +7,17 @@ imports:
   - location: $CP_VERIFY_DIR/pipelines/LSSTCam/verifyFlat.yaml
     include:
       - verifyFlatIsr
+      - verifyFlatDet
+      - verifyFlatExp
+      - verifyFlat
 
 tasks:
   verifyFlatIsr:
     class: lsst.ip.isr.IsrTaskLSST
     config:
       connections.outputExposure: post_isr_image
-      # Make sure brighter-fatter is off.
-      doBrighterFatter: false
-      # Make sure interpolation is on.
-      doInterpolate: true
       doFlat: false
+  verifyFlatDet:
+    class: lsst.cp.verify.CpVerifyFlatTask
+    config:
+      connections.inputExp: post_isr_image


### PR DESCRIPTION
 Update to add analysis_tools to rapid analysis.

 * Remove duplicate config options.
 * Enable analysis_tools tasks.
 * Ensure analysis_tools tasks expect a `post_isr_image` input.