### PR TITLE
DM-52362: Turn on forced phot on diff images in ci_hsc

### DIFF
--- a/pipelines/HSC/DRP-ci_hsc.yaml
+++ b/pipelines/HSC/DRP-ci_hsc.yaml
@@ -75,6 +75,11 @@ tasks:
     class: lsst.pipe.tasks.drpAssociationPipe.DrpAssociationPipeTask
     config:
       doSolarSystemAssociation: false
+  forcedPhotObjectDetector:
+    class: lsst.pipe.tasks.forcedPhotDetector.ForcedPhotDetectorTask
+    config:
+      doDirectPhotometry: true
+      doDifferencePhotometry: true
 
 subsets:
   analysis_tools:


### PR DESCRIPTION
I made an error in DM-51687 by turning off forced photometry on the difference images in HSC. While this should be turned off for HSC in general it should not be turned off for ci_hsc, as that does build difference images and expects the difference catalog columns to exist.