### PR TITLE
DM-52522: Prevent gbdes fail on partial outputs

### DIFF
--- a/bps/resources/LSSTCam/DRP.yaml
+++ b/bps/resources/LSSTCam/DRP.yaml
@@ -154,11 +154,11 @@ pipetask:
   gbdesAstrometricFit:
     requestMemory: 40000
     requestCpus: 10
-    extraRunQuantumOptions: "-j 1 -n 10"
+    extraRunQuantumOptions: "-j 1 -n 10 --no-raise-on-partial-outputs"
   gbdesHealpix3AstrometricFit:
     requestMemory: 40000
     requestCpus: 10
-    extraRunQuantumOptions: "-j 1 -n 10"
+    extraRunQuantumOptions: "-j 1 -n 10 --no-raise-on-partial-outputs"
   refitPsfModel:
     requestMemory: 7000
   skyCorrExperimental:


### PR DESCRIPTION
The extraRunQuantumOptions in the bps resources file overrides the --no-raise-on-partial-outputs in the bps submit yaml file. This option will soon become the default, so we will add it here to avoid short term failures.