### PR TITLE
DM-54843: consolidateSsTables: fix G12 to 0.5, set phot. error floor to 0.01mag

### DIFF
--- a/pipelines/_ingredients/LSSTCam/DRP.yaml
+++ b/pipelines/_ingredients/LSSTCam/DRP.yaml
@@ -111,3 +111,11 @@ tasks:
         110, 113, 116, 117, 120, 121, 123, 124, 155, 157, 158, 160, 161, 165, 166, 168, 169, 170, 177, 178,
         179, 184, 185, 186, 187, 188
       ]
+  consolidateSsTables:
+    class: lsst.pipe.tasks.consolidateSsTables.ConsolidateSsTablesTask
+    config:
+      connections.inputCatalogs: ss_source_associated
+      connections.ssSourceTable: ss_source
+      connections.ssObjectTable: ss_object
+      fixedG12: 0.5
+      magSigmaFloor: 0.01

--- a/pipelines/_ingredients/LSSTCam/DRP.yaml
+++ b/pipelines/_ingredients/LSSTCam/DRP.yaml
@@ -117,5 +117,6 @@ tasks:
       connections.inputCatalogs: ss_source_associated
       connections.ssSourceTable: ss_source
       connections.ssObjectTable: ss_object
-      fixedG12: 0.5
-      magSigmaFloor: 0.01
+      hg12FixedG12: 0.5
+      hg12MagSigmaFloor: 0.05
+      hg12NSigmaClip: 10


### PR DESCRIPTION
Updates to asteroid absolute magnitude fitting for DRP pipelines:
* Fix G12 parameter to 0.5 (don't try to fit it, as we don't have much coverage)
* Mix in 0.01 mag error floor (in quadrature) as DP2 underestimates photometric errors of bright sources