### PR TITLE
DM-54958: Do not use visitSummary PhotoCalibs

### DIFF
--- a/pipelines/_ingredients/base-v2.yaml
+++ b/pipelines/_ingredients/base-v2.yaml
@@ -640,6 +640,10 @@ tasks:
       connections.masked_fraction_warp: pretty_direct_warp_masked_fraction
       idGenerator.release_id: parameters.release_id
       doApplySkyCorr: true
+      # TODO DM-53870: Remove these overrides if using preliminary_visit_image
+      useVisitSummaryPsf: false
+      useVisitSummaryWcs: false
+      useVisitSummaryPhotoCalib: false
   makePrettyPsfMatchedWarp:
     class: lsst.drp.tasks.make_psf_matched_warp.MakePsfMatchedWarpTask
     config:


### PR DESCRIPTION
if making warps from visit_image. They have
already been applied and result in
doubly calibrated images.

Applying WCS's and PSFs from visit_summary are no ops, and unnecessary.