### PR TITLE
DM-55521: Add a LSSTCam DRP-future variant for lsst.images data products.

### DIFF
--- a/config/aggregateDeepCoaddMaskFractions.py
+++ b/config/aggregateDeepCoaddMaskFractions.py
@@ -1,0 +1,18 @@
+# This content needs to go in a file, not a Python block or YAML override,
+# because in (at least) _ingredients/LSSTCam/DRP.yaml, it needs to fire before
+# another file-based config
+# ($ANALYSIS_TOOLS_DIR/config/wholeTractMaskFractionMetrics.py) override and
+# files always apply first.
+
+# Reset to just the mask planes actually present in the cell-based coadds.
+config.maskPlanes = [
+    "NO_DATA",
+    "INTRP",
+    "CR",
+    "SAT",
+    "EDGE",
+    "CLIPPED",
+    "REJECTED",
+    "DETECTED",
+    "INEXACT_PSF",
+]

--- a/pipelines/LSSTCam/DRP-ci_lsstcam-future.yaml
+++ b/pipelines/LSSTCam/DRP-ci_lsstcam-future.yaml
@@ -1,0 +1,8 @@
+description: >
+  LSSTCam specialization of the DRP pipeline with support for the 'future'
+  image storage classes in the `lsst.images` package.
+instrument: lsst.obs.lsst.LsstCam
+imports:
+  - location: $DRP_PIPE_DIR/pipelines/LSSTCam/DRP-ci_lsstcam.yaml
+parameters:
+  image_type: future

--- a/pipelines/LSSTCam/DRP-future.yaml
+++ b/pipelines/LSSTCam/DRP-future.yaml
@@ -1,0 +1,8 @@
+description: >
+  LSSTCam specialization of the DRP pipeline with support for the 'future'
+  image storage classes in the `lsst.images` package.
+instrument: lsst.obs.lsst.LsstCam
+imports:
+  - location: $DRP_PIPE_DIR/pipelines/_ingredients/LSSTCam/DRP.yaml
+parameters:
+  image_type: future

--- a/pipelines/_ingredients/LSSTCam/DRP.yaml
+++ b/pipelines/_ingredients/LSSTCam/DRP.yaml
@@ -12,9 +12,13 @@ imports:
       - analyzeRecalibratedStarPhotometricRefMatch
       - analysis-visit-source
       - step2b-recalibrate-tracts
+      # We drop this analysis task so we can fully reconfigure it with new
+      # mask planes below.
+      - aggregateDeepCoaddMaskPlanes
 parameters:
   use_cell_coadds: true
   schemaFile: "lsstcam.yaml"
+  exclude_aggregate_mask_planes: ["NOT_DEBLENDED"]
 tasks:
   isr:
     class: lsst.ip.isr.IsrTaskLSST
@@ -120,3 +124,11 @@ tasks:
       hg12FixedG12: 0.5
       hg12MagSigmaFloor: 0.05
       hg12NSigmaClip: 10
+  aggregateDeepCoaddMaskFractions:
+    class: lsst.analysis.tools.tasks.WholeTractMaskFractionAnalysisTask
+    config:
+      connections.data: deep_coadd_bin
+      connections.outputName: deep_coadd_tract_mask_fraction
+      file:
+        - $DRP_PIPE_DIR/config/aggregateDeepCoaddMaskFractions.py
+        - $ANALYSIS_TOOLS_DIR/config/wholeTractMaskFractionMetrics.py

--- a/pipelines/_ingredients/base-v2.yaml
+++ b/pipelines/_ingredients/base-v2.yaml
@@ -24,6 +24,7 @@ parameters:
   release_id: 0
   sersic_init_table: object_exp_multiprofit
   use_cell_coadds: false
+  image_type: legacy
 
 tasks:
   # stage1-single-visit production tasks
@@ -255,6 +256,7 @@ tasks:
       connections.visitSummaryList: visit_summary
       connections.multipleCellCoadd: deep_coadd_cell_predetection
       connections.inputMap: deep_coadd_input_map
+      output_image_type: parameters.image_type
       do_input_map: parameters.use_cell_coadds
   assembleTemplateCoadd:
     class: lsst.drp.tasks.assemble_coadd.CompareWarpAssembleCoaddTask
@@ -304,6 +306,7 @@ tasks:
       connections.outputExposure: deep_coadd
       idGenerator.release_id: parameters.release_id
       useCellCoadds: parameters.use_cell_coadds
+      imageType: parameters.image_type
   mergeObjectDetection:
     class: lsst.pipe.tasks.mergeDetections.MergeDetectionsTask
     config:
@@ -322,6 +325,7 @@ tasks:
       connections.deconvolved: deconvolved_deep_coadd
       connections.background: deep_coadd_background
       useCellCoadds: parameters.use_cell_coadds
+      imageType: parameters.image_type
   deblendCoaddFootprints:
     class: lsst.pipe.tasks.deblendCoaddSourcesPipeline.DeblendCoaddSourcesMultiTask
     config:
@@ -336,6 +340,7 @@ tasks:
       connections.scarletModelData: object_scarlet_models
       idGenerator.release_id: parameters.release_id
       useCellCoadds: parameters.use_cell_coadds
+      imageType: parameters.image_type
   measureObjectUnforced:
     class: lsst.pipe.tasks.multiBand.MeasureMergedCoaddSourcesTask
     config:
@@ -352,6 +357,7 @@ tasks:
       connections.background: deep_coadd_background
       idGenerator.release_id: parameters.release_id
       useCellCoadds: parameters.use_cell_coadds
+      imageType: parameters.image_type
   mergeObjectMeasurement:
     class: lsst.pipe.tasks.mergeMeasurements.MergeMeasurementsTask
     config:
@@ -373,6 +379,7 @@ tasks:
       connections.measCat: object_forced_measurement
       idGenerator.release_id: parameters.release_id
       useCellCoadds: parameters.use_cell_coadds
+      imageType: parameters.image_type
   fitDeepCoaddPsfGaussians:
     class: lsst.meas.extensions.multiprofit.pipetasks_fit.MultiProFitCoaddPsfFitTask
     config:
@@ -383,6 +390,7 @@ tasks:
       connections.cat_output: object_psf_multiprofit
       idGenerator.release_id: parameters.release_id
       use_cell_coadds: parameters.use_cell_coadds
+      image_type: parameters.image_type
   fitDeblendedObjectsExp:
     class: lsst.meas.extensions.multiprofit.pipetasks_fit.MultiProFitCoaddExpFitTask
     config:
@@ -396,6 +404,7 @@ tasks:
       connections.cat_output: object_exp_multiprofit
       idGenerator.release_id: parameters.release_id
       use_cell_coadds: parameters.use_cell_coadds
+      image_type: parameters.image_type
   fitDeblendedObjectsSersic:
     class: lsst.meas.extensions.multiprofit.pipetasks_fit.MultiProFitCoaddSersicFitTask
     config:
@@ -409,6 +418,7 @@ tasks:
       connections.cat_output: object_sersic_multiprofit
       idGenerator.release_id: parameters.release_id
       use_cell_coadds: parameters.use_cell_coadds
+      image_type: parameters.image_type
   rewriteObject:
     class: lsst.pipe.tasks.postprocess.WriteObjectTableTask
     config:

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -709,6 +709,22 @@ class PipelineTestCase(unittest.TestCase):
         )
         tester.run(butler, self)
 
+    def test_lsstcam_drp_future(self):
+        butler = self.makeButler(writeable=True)
+        tester = PipelineStepTester(
+            os.path.join(PIPELINES_DIR, "LSSTCam", "DRP-future.yaml"),
+            [
+                "#stage1-single-visit",
+                "#stage2-recalibrate",
+                "#stage3-coadd",
+                "#stage4-measure-variability",
+            ],
+            initial_dataset_types=REFCATS,
+            expected_inputs=COMMON_INPUTS | LSSTCAM_INPUTS | {"fgcmLookUpTable"},
+            expected_outputs=(COMMON_V2_OUTPUTS | {"source"}) - {"deep_coadd_background"},
+        )
+        tester.run(butler, self)
+
     def test_lsstcam_drp_fl(self):
         butler = self.makeButler(writeable=True)
         tester = PipelineStepTester(


### PR DESCRIPTION
So far this just expects deep_coadd to use lsst.images (as in early DP2), and updates the coadd-processing pipelines accordingly.

This should work with the dp2_prep_future data repository at USDF.  It should also work if the pipeline is run from the beginning into an empty repository, and allowed to register its own dataset types.